### PR TITLE
Report an error on names/linknames which would exceed the buffer size

### DIFF
--- a/src/microtar.c
+++ b/src/microtar.c
@@ -173,8 +173,10 @@ static int file_seek(mtar_t *tar, unsigned offset) {
 }
 
 static int file_close(mtar_t *tar) {
-  if (tar->stream != NULL)
+  if (tar->stream != NULL){
     fclose(tar->stream);
+    tar->stream = NULL;
+  }
   return MTAR_ESUCCESS;
 }
 

--- a/src/microtar.c
+++ b/src/microtar.c
@@ -322,6 +322,9 @@ int mtar_read_data(mtar_t *tar, void *ptr, unsigned size) {
 
 int mtar_write_header(mtar_t *tar, const mtar_header_t *h) {
   mtar_raw_header_t rh;
+  /* If name exceeds buffer length, return error */
+  if(strlen(h->name) > 99 || strlen(h->linkname) > 99)
+    return MTAR_EFAILURE;
   /* Build raw header and write */
   header_to_raw(&rh, h);
   tar->remaining_data = h->size;
@@ -331,6 +334,9 @@ int mtar_write_header(mtar_t *tar, const mtar_header_t *h) {
 
 int mtar_write_file_header(mtar_t *tar, const char *name, unsigned size) {
   mtar_header_t h;
+  /* If name exceeds buffer length, return error */
+  if(strlen(name) > 99)
+    return MTAR_EFAILURE;
   /* Build header */
   memset(&h, 0, sizeof(h));
   strcpy(h.name, name);
@@ -344,6 +350,9 @@ int mtar_write_file_header(mtar_t *tar, const char *name, unsigned size) {
 
 int mtar_write_dir_header(mtar_t *tar, const char *name) {
   mtar_header_t h;
+  /* If name exceeds buffer length, return error */
+  if(strlen(name) > 99)
+    return MTAR_EFAILURE;
   /* Build header */
   memset(&h, 0, sizeof(h));
   strcpy(h.name, name);

--- a/src/microtar.c
+++ b/src/microtar.c
@@ -106,12 +106,12 @@ static int raw_to_header(mtar_header_t *h, const mtar_raw_header_t *rh) {
   sscanf(rh->owner, "%o", &h->owner);
   sscanf(rh->size, "%o", &h->size);
   sscanf(rh->mtime, "%o", &h->mtime);
+  h->type = rh->type;
 
   /* If name or linkname exceeds buffer length, return error */
-  if(strlen(rh->name) > MTAR_BUFLEN - 1 || strlen(rh->linkname) > MTAR_BUFLEN - 1)
+  if(strlen(rh->name) > MTAR_BUFLEN - 1 || strlen(rh->linkname) > MTAR_BUFLEN - 1 || h->type == 'L')
     return MTAR_EBUFOVERFLOW;
-  
-  h->type = rh->type;
+
   strcpy(h->name, rh->name);
   strcpy(h->linkname, rh->linkname);
 

--- a/src/microtar.c
+++ b/src/microtar.c
@@ -107,6 +107,10 @@ static int raw_to_header(mtar_header_t *h, const mtar_raw_header_t *rh) {
   sscanf(rh->owner, "%o", &h->owner);
   sscanf(rh->size, "%o", &h->size);
   sscanf(rh->mtime, "%o", &h->mtime);
+  
+  if (h->size > 99)
+    return MTAR_EFAILURE;
+  
   h->type = rh->type;
   strcpy(h->name, rh->name);
   strcpy(h->linkname, rh->linkname);
@@ -169,7 +173,8 @@ static int file_seek(mtar_t *tar, unsigned offset) {
 }
 
 static int file_close(mtar_t *tar) {
-  fclose(tar->stream);
+  if (tar->stream != NULL)
+    fclose(tar->stream);
   return MTAR_ESUCCESS;
 }
 

--- a/src/microtar.c
+++ b/src/microtar.c
@@ -109,7 +109,7 @@ static int raw_to_header(mtar_header_t *h, const mtar_raw_header_t *rh) {
   h->type = rh->type;
 
   /* If name or linkname exceeds buffer length, return error */
-  if(strlen(rh->name) > MTAR_BUFLEN - 1 || strlen(rh->linkname) > MTAR_BUFLEN - 1 || h->type == 'L')
+  if(strlen(rh->name) >= MTAR_BUFLEN || strlen(rh->linkname) >= MTAR_BUFLEN || h->type == MTAR_TLLNK)
     return MTAR_EBUFOVERFLOW;
 
   strcpy(h->name, rh->name);

--- a/src/microtar.h
+++ b/src/microtar.h
@@ -17,6 +17,7 @@ extern "C"
 #include <stdlib.h>
 
 #define MTAR_VERSION "0.1.0"
+#define MTAR_BUFLEN 100
 
 enum {
   MTAR_ESUCCESS     =  0,
@@ -27,7 +28,8 @@ enum {
   MTAR_ESEEKFAIL    = -5,
   MTAR_EBADCHKSUM   = -6,
   MTAR_ENULLRECORD  = -7,
-  MTAR_ENOTFOUND    = -8
+  MTAR_ENOTFOUND    = -8,
+  MTAR_EBUFOVERFLOW = -9
 };
 
 enum {
@@ -46,8 +48,8 @@ typedef struct {
   unsigned size;
   unsigned mtime;
   unsigned type;
-  char name[100];
-  char linkname[100];
+  char name[MTAR_BUFLEN];
+  char linkname[MTAR_BUFLEN];
 } mtar_header_t;
 
 

--- a/src/microtar.h
+++ b/src/microtar.h
@@ -39,7 +39,8 @@ enum {
   MTAR_TCHR   = '3',
   MTAR_TBLK   = '4',
   MTAR_TDIR   = '5',
-  MTAR_TFIFO  = '6'
+  MTAR_TFIFO  = '6',
+  MTAR_TLLNK  = 'L'
 };
 
 typedef struct {


### PR DESCRIPTION
Return `MTAR_EFAILURE` on what would currently be a buffer overflow.

Note: this does not cover the case where a tar of unknown origin contains filenames exceeding 100B. Which currently produces the following output using the README read example:

```
$ ./a.out 
././@LongLink (102 bytes)
0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789 (0 bytes)
```

here, the tarfile contains one file with a >100B filename. I think that case should probably be handled in `raw_to_header`, but wasn't sure, so I left it.