### PR TITLE
Adding longer paths in ustar extension format.

### DIFF
--- a/src/microtar.h
+++ b/src/microtar.h
@@ -27,7 +27,8 @@ enum {
   MTAR_ESEEKFAIL    = -5,
   MTAR_EBADCHKSUM   = -6,
   MTAR_ENULLRECORD  = -7,
-  MTAR_ENOTFOUND    = -8
+  MTAR_ENOTFOUND    = -8,
+  MTAR_ENAME = -9
 };
 
 enum {
@@ -46,7 +47,7 @@ typedef struct {
   unsigned size;
   unsigned mtime;
   unsigned type;
-  char name[100];
+  char name[256];
   char linkname[100];
 } mtar_header_t;
 


### PR DESCRIPTION
This patch adds minimal support for longer paths using Unix Standard TAR. The path limit is extended to 256 bytes, nonetheless filename must fit in less than 100 characters. A new error value `MTAR_ENAME` may be returned for invalid input paths.

[bsd tar manual](https://man.freebsd.org/cgi/man.cgi?query=tar&apropos=0&sektion=5&manpath=FreeBSD+7.0-RELEASE&arch=default&format=html)